### PR TITLE
Update URL in README

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 Example code for *HTML5 for Publishers*, now available from O'Reilly Media:
 
-http://shop.oreilly.com/product/0636920022473.do
+https://www.oreilly.com/library/view/html5-for-publishers/9781449320065/


### PR DESCRIPTION
Changed the book URL (ORM no longer sells books, and "shop.oreilly.com" URLs aren't being redirected).